### PR TITLE
feat: add auto-play button for AI turns

### DIFF
--- a/codenames_game/static/index.html
+++ b/codenames_game/static/index.html
@@ -260,6 +260,13 @@
                                 <button id="trigger-ai-btn" class="btn btn-primary">Trigger AI Action</button>
                             </div>
 
+                            <!-- Auto-play AI Turns Button -->
+                            <div id="autoplay-panel" class="action-card" style="display: none;">
+                                <p id="autoplay-text">Run all AI turns automatically</p>
+                                <button id="autoplay-btn" class="btn btn-success">▶ Auto-play AI Turns</button>
+                                <button id="stop-autoplay-btn" class="btn btn-danger" style="display: none;">⏹ Stop Auto-play</button>
+                            </div>
+
                             <!-- Waiting Message -->
                             <div id="waiting-panel" class="action-card" style="display: none;">
                                 <p id="waiting-text">Waiting for other team...</p>

--- a/codenames_game/static/styles.css
+++ b/codenames_game/static/styles.css
@@ -161,6 +161,16 @@ h1, h2, h3, h4 {
     color: white;
 }
 
+.btn-success {
+    background: linear-gradient(135deg, #10b981, #059669);
+    color: white;
+}
+
+.btn-danger {
+    background: linear-gradient(135deg, #ef4444, #dc2626);
+    color: white;
+}
+
 .btn-ghost {
     background: transparent;
     color: var(--text-secondary);


### PR DESCRIPTION
Add a new "Auto-play AI Turns" button that automatically executes all AI actions until the next human player's turn. This feature allows users to run entire games with all AI players, or quickly advance through AI turns without manual triggering.

Key features:
- Auto-play button visible when AI players are present in the game
- Automatically triggers consecutive AI actions until a human turn
- Cancellable via "Stop Auto-play" button during execution
- 500ms delay between actions for visibility
- Gracefully handles errors and game end conditions
- Works for games with all AI players (runs entire game)

Changes:
- Added autoplay panel UI with start/stop buttons
- Implemented auto-play state management and logic
- Added continueAutoPlayIfNeeded() to chain AI actions
- Added btn-success and btn-danger CSS classes for buttons